### PR TITLE
Extrapolates timestepper to separate class

### DIFF
--- a/include/Game.hpp
+++ b/include/Game.hpp
@@ -4,6 +4,7 @@
 #include "RenderWindow.hpp"
 #include "Entity.hpp"
 #include "Utils.hpp"
+#include "Timestepper.hpp"
 
 class Game
 {
@@ -14,4 +15,5 @@ private:
     RenderWindow window;
     std::vector<Entity> entities;
     bool gameRunning;
+    TimeStepper timeStepper;
 };

--- a/include/Timestepper.hpp
+++ b/include/Timestepper.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+class TimeStepper
+{
+public:
+    TimeStepper(float timeStep);
+    void update();
+    bool shouldUpdate() const;
+    void reset();
+
+private:
+    float accumulator;
+    float currentTime;
+    float timeStep;
+};

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3,7 +3,7 @@
 #include "Game.hpp"
 
 Game::Game() 
-:window("ZEN_GARDEN v1.0", 1280, 720), gameRunning(true), timeStepper(0.01f)
+:window("ZEN_GARDEN v0.01", 1280, 720), gameRunning(true), timeStepper(0.01f)
 {
     SDL_Texture* tx_grass = window.loadTexture("res/gfx/ground_grass_1.png");
 
@@ -31,9 +31,9 @@ void Game::run()
 
         if (timeStepper.shouldUpdate())
         {
-            // Movement logic
-            std::cout << "step" << std::endl;
+            // MOVEMENT PER FRAME OCCURS HERE
 
+            std::cout << "step" << std::endl;
             timeStepper.reset();
         }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -23,7 +23,7 @@ void Game::run()
 
          timeStepper.update();
 
-         while (SDL_PollEvent(&event))
+        while (SDL_PollEvent(&event))
         {
             if (event.type == SDL_QUIT)
                 gameRunning = false;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1,7 +1,9 @@
+#include <iostream>
+
 #include "Game.hpp"
 
 Game::Game() 
-:window("ZEN_GARDEN v1.0", 1280, 720), gameRunning(true)
+:window("ZEN_GARDEN v1.0", 1280, 720), gameRunning(true), timeStepper(0.01f)
 {
     SDL_Texture* tx_grass = window.loadTexture("res/gfx/ground_grass_1.png");
 
@@ -12,9 +14,6 @@ Game::Game()
 
 void Game::run()
 {
-    const float timeStep = 0.01f;
-    float accumulator = 0.0f;
-    float currentTime = utils::TimeInSeconds();
 
     SDL_Event event;
 
@@ -22,23 +21,20 @@ void Game::run()
     {
         int firstTick = SDL_GetTicks();
 
-        float newTime = utils::TimeInSeconds();
-        float frameTime = newTime - currentTime;
+         timeStepper.update();
 
-        currentTime = newTime;
-        accumulator += frameTime;
-
-        while (accumulator >= timeStep)
+         while (SDL_PollEvent(&event))
         {
-            while (SDL_PollEvent(&event))
-            {
-                if (event.type == SDL_QUIT)
-                    gameRunning = false;
-            }
+            if (event.type == SDL_QUIT)
+                gameRunning = false;
+        }
 
-            // movement logic
+        if (timeStepper.shouldUpdate())
+        {
+            // Movement logic
+            std::cout << "step" << std::endl;
 
-            accumulator -= timeStep;
+            timeStepper.reset();
         }
 
         window.clear();

--- a/src/timestepper.cpp
+++ b/src/timestepper.cpp
@@ -1,0 +1,26 @@
+#include "TimeStepper.hpp"
+#include "Utils.hpp"
+
+TimeStepper::TimeStepper(float timeStep)
+    :accumulator(0.0f), currentTime(utils::TimeInSeconds()), timeStep(timeStep)
+{
+}
+
+void TimeStepper::update()
+{
+    float newTime = utils::TimeInSeconds();
+    float frameTime = newTime - currentTime;
+
+    currentTime = newTime;
+    accumulator += frameTime;
+}
+
+bool TimeStepper::shouldUpdate() const
+{
+    return accumulator >= timeStep;
+}
+
+void TimeStepper::reset()
+{
+    accumulator -= timeStep;
+}


### PR DESCRIPTION
- Moves the timestepping functionality to it's own timestep class. 
- Cleans up some of the functionality for readability.

Also:
- Updates version number to be less than zero (because this game currently doesn't do anything but render 3 boxes of grass on the screen).